### PR TITLE
Update api_url to be pulled from ENV and populated by run.sh

### DIFF
--- a/packages/localdeck-configurator/homeassistant/run.sh
+++ b/packages/localdeck-configurator/homeassistant/run.sh
@@ -7,4 +7,6 @@ export NUXT_APP_BUILD_ASSETS_DIR="$(bashio::addon.ingress_entry)/_nuxt"
 
 export NUXT_API_TOKEN=${SUPERVISOR_TOKEN}
 
+export NUXT_API_URL="http://supervisor/core/api"
+
 node ./server/index.mjs

--- a/packages/localdeck-configurator/nuxt.config.ts
+++ b/packages/localdeck-configurator/nuxt.config.ts
@@ -19,7 +19,7 @@ export default defineNuxtConfig({
         public: {baseUrl: ''},
 
         api_token: '',
-        api_url: 'http://supervisor/core/api',
+        api_url: '', //Allow this to be overridden by env
 
         filesDir: '/homeassistant/esphome'
     },


### PR DESCRIPTION
**Context:**
I'm attempting to run the localdeck configurator docker container running alongside my home assistant docker container as I don't run home assistant OS.

**Problem**
For some reason I'm completely unable to ever override the value of the `api_url` within the container and this results in the below host lookup error:
![image](https://github.com/LocalBytes/localdeck-config/assets/7502848/d5f84976-5371-493a-9b56-89fad7a55d0f)

What I've tried (Multiple ways of setting the value of `NUXT_API_URL` which should work according to nuxt docs):
- Custom .env file 
- ENV variable added to docker container
- Custom run.sh file

![image](https://github.com/LocalBytes/localdeck-config/assets/7502848/ec5202e0-ca17-4aaf-b67a-cea686ed1c1c)

All of the above result in the same `Could not resolve host` error.

I also added `supervisor` as an extra host to the container pointing to the host, but as my hass container is on port 8123 it still gives an error:
![image](https://github.com/LocalBytes/localdeck-config/assets/7502848/67ec6a99-ae28-411d-84d8-f3bf65f2e322)

**Solution (I hope):**
Hopefully by setting the value of `api_url` to be an empty string and filled from env values, anyone should be able to override it as needed for their specific use cases