### PR TITLE
fix/config persistence

### DIFF
--- a/packages/localdeck-configurator/src/pages/debug.vue
+++ b/packages/localdeck-configurator/src/pages/debug.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="container py-5 mx-auto">
+    <h1>Debugger</h1>
+
+    <label>
+      Config URL
+      <input
+        v-model="configUrl"
+        class="input border-secondary inline-block"
+        type="text"
+      >
+
+    </label>
+
+    <div>
+      <h2>Decompressed</h2>
+      <pre>{{ decompressed }}</pre>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { decompress } from '@localbytes/localdeck-components/src/utils/compression';
+
+const configUrl = ref<string>('');
+
+const decompressed = computed(() => {
+  try {
+    const url: URL = new URL(configUrl.value);
+    const extracted = url.searchParams.get('config');
+    return decompress(extracted);
+  }
+  catch (e) {
+    return e;
+  }
+});
+</script>

--- a/packages/localdeck-configurator/src/pages/editor.vue
+++ b/packages/localdeck-configurator/src/pages/editor.vue
@@ -145,7 +145,6 @@ const print = async () => {
 };
 
 const reset = () => {
-  if (!confirm('Are you sure you want to reset?')) return;
   config.resetChanges();
   resetting.value = false;
 };

--- a/packages/localdeck-configurator/src/server/api/editor.get.ts
+++ b/packages/localdeck-configurator/src/server/api/editor.get.ts
@@ -20,10 +20,5 @@ export default defineEventHandler(async (event) => {
   const matchFriendly = content.match(/friendly_name: (.*)/);
   if (matchFriendly) config.title = matchFriendly[1];
 
-  config.buttons = _(config.buttons)
-    .sortBy('keyNum')
-    .keyBy('keyNum')
-    .value();
-
   return { configStr, config, content };
 });

--- a/packages/localdeck-configurator/src/server/api/editor.get.ts
+++ b/packages/localdeck-configurator/src/server/api/editor.get.ts
@@ -1,9 +1,7 @@
 import * as fs from 'fs/promises';
-import _ from 'lodash';
 
 import { decompress } from '@localbytes/localdeck-components/src/utils/compression';
 import type { PadEditor } from '@localbytes/localdeck-components/src/utils/PadCfg';
-import { newPadEditor } from '@localbytes/localdeck-components/src/utils/PadCfg';
 
 export default defineEventHandler(async (event) => {
   const { filesDir } = useRuntimeConfig();
@@ -19,6 +17,8 @@ export default defineEventHandler(async (event) => {
 
   const matchFriendly = content.match(/friendly_name: (.*)/);
   if (matchFriendly) config.title = matchFriendly[1];
+
+  config.buttons ??= {};
 
   return { configStr, config, content };
 });

--- a/packages/localdeck-configurator/src/server/api/editor.get.ts
+++ b/packages/localdeck-configurator/src/server/api/editor.get.ts
@@ -12,7 +12,7 @@ export default defineEventHandler(async (event) => {
   const configMatch = content.match(/configurator\?config=(.*)/);
   const configStr = configMatch ? decodeURIComponent(configMatch[1]) : null;
 
-  const config = configStr ? decompress<PadEditor>(configStr) : newPadEditor();
+  const config = configStr ? decompress<PadEditor>(configStr) : { title: 'LocalDeck', buttons: {} };
 
   const matchName = content.match(/name: (.*)/);
   if (matchName) config.title = matchName[1];

--- a/packages/localdeck-configurator/tests/e2e/file-import.test.ts
+++ b/packages/localdeck-configurator/tests/e2e/file-import.test.ts
@@ -46,7 +46,15 @@ describe('Import Workflow', async () => {
     // Load the page
     console.log('Loading Page');
     const page = (await createPage('/'));
+
+    const responsePromise = page.waitForResponse(r => r.url().includes('/api/editor'));
+
+    console.log('Clicking');
     await page.getByText(FILENAME).click();
+
+    const response = await responsePromise.then(r => r.json());
+    expect(response.configStr).toBeNull();
+    expect(response.config).toMatchObject({ title: 'LocalBytes LocalDeck 9751c4', buttons: {} });
 
     // Update the friendly name
     console.log('Updating Friendly Name');

--- a/packages/localdeck-configurator/tests/e2e/file-import.test.ts
+++ b/packages/localdeck-configurator/tests/e2e/file-import.test.ts
@@ -29,7 +29,7 @@ wifi:
 const FILENAME = 'test-import.yaml';
 
 describe('Import Workflow', async () => {
-  await setupNuxt({});
+  await setupNuxt();
 
   test('Parse the original file', async () => {
     const content = espHomeYaml.parse(preImportExample) as object;

--- a/packages/localdeck-configurator/tests/e2e/hail-mary.test.ts
+++ b/packages/localdeck-configurator/tests/e2e/hail-mary.test.ts
@@ -34,32 +34,44 @@ describe('Hail Mary', async () => {
     await page.getByText(FILENAME).click();
 
     console.log('Setting Buttons');
-    await setButton(page, 1, { name: 'Livingroom Bulb', entity: 'light.livingroom_bulb' });
-    await setButton(page, 2, { name: 'Kitchen Bulb', entity: 'light.kitchen_bulb' });
-    await setButton(page, 3, { name: 'Bedroom Bulb', entity: 'light.bedroom_bulb' });
-    await setButton(page, 4, { name: 'Bathroom Bulb', entity: 'light.bathroom_bulb' });
-    await setButton(page, 5, { name: 'Hallway Bulb', entity: 'light.hallway_bulb' });
-    await setButton(page, 6, { name: 'Porch Bulb', entity: 'light.porch_bulb' });
-    await setButton(page, 7, { name: 'Garage Bulb', entity: 'light.garage_bulb' });
-    await setButton(page, 8, { name: 'Backyard Bulb', entity: 'light.backyard_bulb' });
-    await setButton(page, 9, { name: 'Frontyard Bulb', entity: 'light.frontyard_bulb' });
-    await setButton(page, 10, { name: 'Basement Bulb', entity: 'light.basement_bulb' });
-    await setButton(page, 11, { name: 'Attic Bulb', entity: 'light.attic_bulb' });
-    await setButton(page, 12, { name: 'Office Bulb', entity: 'light.office_bulb' });
-    await setButton(page, 13, { name: 'Library Bulb', entity: 'light.library_bulb' });
-    await setButton(page, 14, { name: 'Study Bulb', entity: 'light.study_bulb' });
-    await setButton(page, 15, { name: 'Lab Bulb', entity: 'light.lab_bulb' });
-    await setButton(page, 16, { name: 'Classroom Bulb', entity: 'light.classroom_bulb' });
-    await setButton(page, 17, { name: 'Gym Bulb', entity: 'light.gym_bulb' });
-    await setButton(page, 18, { name: 'Pool Bulb', entity: 'light.pool_bulb' });
-    await setButton(page, 19, { name: 'Spa Bulb', entity: 'light.spa_bulb' });
-    await setButton(page, 20, { name: 'Sauna Bulb', entity: 'light.sauna_bulb' });
-    await setButton(page, 21, { name: 'Cinema Bulb', entity: 'light.cinema_bulb' });
-    await setButton(page, 22, { name: 'Bar Bulb', entity: 'light.bar_bulb' });
-    await setButton(page, 23, { name: 'Kitchenette Bulb', entity: 'light.kitchenette_bulb' });
-    await setButton(page, 24, { name: 'Diningroom Bulb', entity: 'light.diningroom_bulb' });
+    const buttons = [
+      { keynum: 1, name: 'Livingroom Bulb', entity: 'light.livingroom_bulb' },
+      { keynum: 2, name: 'Kitchen Bulb', entity: 'light.kitchen_bulb' },
+      { keynum: 3, name: 'Bedroom Bulb', entity: 'light.bedroom_bulb' },
+      { keynum: 4, name: 'Bathroom Bulb', entity: 'light.bathroom_bulb' },
+      { keynum: 5, name: 'Hallway Bulb', entity: 'light.hallway_bulb' },
+      { keynum: 6, name: 'Porch Bulb', entity: 'light.porch_bulb' },
+      { keynum: 7, name: 'Garage Bulb', entity: 'light.garage_bulb' },
+      { keynum: 8, name: 'Backyard Bulb', entity: 'light.backyard_bulb' },
+      { keynum: 9, name: 'Frontyard Bulb', entity: 'light.frontyard_bulb' },
+      { keynum: 10, name: 'Basement Bulb', entity: 'light.basement_bulb' },
+      { keynum: 11, name: 'Attic Bulb', entity: 'light.attic_bulb' },
+      { keynum: 12, name: 'Office Bulb', entity: 'light.office_bulb' },
+      { keynum: 13, name: 'Library Bulb', entity: 'light.library_bulb' },
+      { keynum: 14, name: 'Study Bulb', entity: 'light.study_bulb' },
+      { keynum: 15, name: 'Lab Bulb', entity: 'light.lab_bulb' },
+      { keynum: 16, name: 'Classroom Bulb', entity: 'light.classroom_bulb' },
+      { keynum: 17, name: 'Gym Bulb', entity: 'light.gym_bulb' },
+      { keynum: 18, name: 'Pool Bulb', entity: 'light.pool_bulb' },
+      { keynum: 19, name: 'Spa Bulb', entity: 'light.spa_bulb' },
+      { keynum: 20, name: 'Sauna Bulb', entity: 'light.sauna_bulb' },
+      { keynum: 21, name: 'Cinema Bulb', entity: 'light.cinema_bulb' },
+      { keynum: 22, name: 'Bar Bulb', entity: 'light.bar_bulb' },
+      { keynum: 23, name: 'Kitchenette Bulb', entity: 'light.kitchenette_bulb' },
+      { keynum: 24, name: 'Diningroom Bulb', entity: 'light.diningroom_bulb' },
+    ];
+
+    for (const button of buttons) {
+      await setButton(page, button.keynum, { name: button.name, entity: button.entity });
+    }
 
     console.log('Saving');
     await page.getByRole('button', { name: 'Save' }).click();
+    await page.reload();
+
+    console.log('Checking');
+    for (const button of buttons) {
+      await page.getByText(button.name).isVisible();
+    }
   });
 });

--- a/packages/localdeck-configurator/tests/e2e/hail-mary.test.ts
+++ b/packages/localdeck-configurator/tests/e2e/hail-mary.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment nuxt
+
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+
+import { beforeEach, describe, test } from 'vitest';
+import { createPage } from '@nuxt/test-utils/e2e';
+import { setupNuxt } from '~~/tests/utils';
+
+const FILENAME = 'test-hailmary.yaml';
+type NuxtPage = Awaited<ReturnType<typeof createPage>>;
+
+async function setButton(page: NuxtPage, keynum: number, { name, entity }) {
+  console.log(`Setting Button ${keynum} to ${name} (${entity})`);
+  await page.click(`div[data-keynum="${keynum}"]`);
+
+  await page.getByRole('textbox', { name: 'Entity' }).fill(entity);
+  await page.getByPlaceholder('Type here').fill(name);
+}
+
+describe('Hail Mary', async () => {
+  await setupNuxt();
+
+  beforeEach(async () => {
+    const runtimeConfig = useRuntimeConfig();
+    const filePath = path.join(runtimeConfig.filesDir, FILENAME);
+    await fs.writeFile(filePath, '');
+  });
+
+  test('Set All the buttons', async () => {
+    // Load the page
+    console.log('Loading Page');
+    const page = await createPage('/');
+    await page.getByText(FILENAME).click();
+
+    console.log('Setting Buttons');
+    await setButton(page, 1, { name: 'Livingroom Bulb', entity: 'light.livingroom_bulb' });
+    await setButton(page, 2, { name: 'Kitchen Bulb', entity: 'light.kitchen_bulb' });
+    await setButton(page, 3, { name: 'Bedroom Bulb', entity: 'light.bedroom_bulb' });
+    await setButton(page, 4, { name: 'Bathroom Bulb', entity: 'light.bathroom_bulb' });
+    await setButton(page, 5, { name: 'Hallway Bulb', entity: 'light.hallway_bulb' });
+    await setButton(page, 6, { name: 'Porch Bulb', entity: 'light.porch_bulb' });
+    await setButton(page, 7, { name: 'Garage Bulb', entity: 'light.garage_bulb' });
+    await setButton(page, 8, { name: 'Backyard Bulb', entity: 'light.backyard_bulb' });
+    await setButton(page, 9, { name: 'Frontyard Bulb', entity: 'light.frontyard_bulb' });
+    await setButton(page, 10, { name: 'Basement Bulb', entity: 'light.basement_bulb' });
+    await setButton(page, 11, { name: 'Attic Bulb', entity: 'light.attic_bulb' });
+    await setButton(page, 12, { name: 'Office Bulb', entity: 'light.office_bulb' });
+    await setButton(page, 13, { name: 'Library Bulb', entity: 'light.library_bulb' });
+    await setButton(page, 14, { name: 'Study Bulb', entity: 'light.study_bulb' });
+    await setButton(page, 15, { name: 'Lab Bulb', entity: 'light.lab_bulb' });
+    await setButton(page, 16, { name: 'Classroom Bulb', entity: 'light.classroom_bulb' });
+    await setButton(page, 17, { name: 'Gym Bulb', entity: 'light.gym_bulb' });
+    await setButton(page, 18, { name: 'Pool Bulb', entity: 'light.pool_bulb' });
+    await setButton(page, 19, { name: 'Spa Bulb', entity: 'light.spa_bulb' });
+    await setButton(page, 20, { name: 'Sauna Bulb', entity: 'light.sauna_bulb' });
+    await setButton(page, 21, { name: 'Cinema Bulb', entity: 'light.cinema_bulb' });
+    await setButton(page, 22, { name: 'Bar Bulb', entity: 'light.bar_bulb' });
+    await setButton(page, 23, { name: 'Kitchenette Bulb', entity: 'light.kitchenette_bulb' });
+    await setButton(page, 24, { name: 'Diningroom Bulb', entity: 'light.diningroom_bulb' });
+
+    console.log('Saving');
+    await page.getByRole('button', { name: 'Save' }).click();
+  });
+});

--- a/packages/localdeck-configurator/tests/e2e/resetting.test.ts
+++ b/packages/localdeck-configurator/tests/e2e/resetting.test.ts
@@ -49,6 +49,6 @@ describe('Resetting Workflow', async () => {
     const response = page.waitForResponse(r => r.url().includes('/api/editor'));
     await page.reload();
     const responseJson = await response.then(r => r.json());
-    expect(responseJson.config).toMatchObject({ buttons: {} });
+    expect(responseJson.config).toMatchObject({ title: 'LocalDeck', buttons: {} });
   });
 });

--- a/packages/localdeck-configurator/tests/e2e/resetting.test.ts
+++ b/packages/localdeck-configurator/tests/e2e/resetting.test.ts
@@ -3,27 +3,52 @@
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 
-import { describe, test } from 'vitest';
+import { beforeEach, describe, expect, test } from 'vitest';
 import { createPage } from '@nuxt/test-utils/e2e';
 import { setupNuxt } from '~~/tests/utils';
 
 const FILENAME = 'test-resetting.yaml';
+type NuxtPage = Awaited<ReturnType<typeof createPage>>;
+
+async function setButton(page: NuxtPage, keynum: number, { name, entity }) {
+  console.log(`Setting Button ${keynum} to ${name} (${entity})`);
+  await page.click(`div[data-keynum="${keynum}"]`);
+
+  await page.getByRole('textbox', { name: 'Entity' }).fill(entity);
+  await page.getByPlaceholder('Type here').fill(name);
+}
 
 describe('Resetting Workflow', async () => {
   await setupNuxt();
 
-  test('Resetting the configuration', async () => {
+  beforeEach(async () => {
     const runtimeConfig = useRuntimeConfig();
     const filePath = path.join(runtimeConfig.filesDir, FILENAME);
     await fs.writeFile(filePath, '');
+  });
 
+  test('Resetting the configuration', async () => {
     // Load the page
     console.log('Loading Page');
     const page = await createPage('/');
     await page.getByText(FILENAME).click();
 
-    // Set button 1 to be Livingroom Bulb (light.livingroom_bulb) and save
-    console.log('Setting Button 1');
-    await page.click('div[data-keynum="1"]');
+    console.log('Setting Buttons');
+    await setButton(page, 1, { name: 'Livingroom Bulb', entity: 'light.livingroom_bulb' });
+    await setButton(page, 2, { name: 'Kitchen Bulb', entity: 'light.kitchen_bulb' });
+
+    console.log('Saving & Resetting');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await page.locator('.modal', { hasText: 'Saving' }).getByText('✕').click();
+
+    await page.getByRole('button', { name: 'Reset' }).click();
+    await page.locator('.modal', { hasText: 'Are you sure?' }).getByRole('button', { name: 'Reset' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    console.log('Checking Reset in Network');
+    const response = page.waitForResponse(r => r.url().includes('/api/editor'));
+    await page.reload();
+    const responseJson = await response.then(r => r.json());
+    expect(responseJson.config).toMatchObject({ buttons: {} });
   });
 });

--- a/packages/localdeck-configurator/tests/e2e/resetting.test.ts
+++ b/packages/localdeck-configurator/tests/e2e/resetting.test.ts
@@ -10,7 +10,7 @@ import { setupNuxt } from '~~/tests/utils';
 const FILENAME = 'test-resetting.yaml';
 
 describe('Resetting Workflow', async () => {
-  await setupNuxt({});
+  await setupNuxt();
 
   test('Resetting the configuration', async () => {
     const runtimeConfig = useRuntimeConfig();

--- a/packages/localdeck-configurator/tests/utils.ts
+++ b/packages/localdeck-configurator/tests/utils.ts
@@ -1,9 +1,10 @@
+import type { TestOptions } from '@nuxt/test-utils/e2e';
 import { setup } from '@nuxt/test-utils/e2e';
-import type { TestOptions } from '@nuxt/test-utils';
 
 export const setupNuxt = (options?: Partial<TestOptions>) => {
   if (process.env.CI) return setup();
   else return setup({
+    host: 'http://localhost:3000',
     build: false,
     buildDir: '.output',
     nuxtConfig: {
@@ -13,6 +14,6 @@ export const setupNuxt = (options?: Partial<TestOptions>) => {
         },
       },
     },
-    ...options,
+    ...(options ?? {}),
   });
 };


### PR DESCRIPTION
We have discovered the root of an issue where the buttons would fail to persist.
This was caused by code left over from when we saved the entire config (as opposed to the change set), and as such, we had the following to get them into the correct order...

```ts
  config.buttons = _(config.buttons)
    .sortBy('keyNum')
    .keyBy('keyNum')
    .value();
```

This, however, presented an issue when the "keyNum" was absent (as was the case with changeset-based saving)
Still not quite sure why this wasn't reproducing locally until the hail-mary test.

Fixes: #30 