### PR TITLE
Use native repeat action for bliplights

### DIFF
--- a/packages/localdeck-codegen/src/scripts/blip-light.ts
+++ b/packages/localdeck-codegen/src/scripts/blip-light.ts
@@ -1,25 +1,33 @@
 import {Script} from "esphome-config-ts/dist/components/index.js";
 import {lambda} from "esphome-config-ts/dist/yaml/index.js";
 
-const fadeOut = Array.from({length: 20}, (_, i) => i)
-    .map(i => Math.max(100 - (i * 5), 0))
-    .flatMap(brightness => [{
-        'light.addressable_set': {
-            id: "ledstrip",
-            range_from: lambda('return led_index;'),
-            range_to: lambda('return led_index;'),
-            red: `${brightness}%`,
-            green: `${brightness}%`,
-            blue: `${brightness}%`,
-            white: `${brightness}%`
-        },
-    }, {
-        'delay': '25ms'
-    }])
+// How many steps to take when dimming the lights
+const iterations = '20';
+
+// Brightness calculation. Note "iteration" is a counter the repeat action provides.
+// https://esphome.io/automations/actions.html#repeat-action
+const brightness = lambda(`return 1.0 - ((float)iteration / ${iterations});`);
 
 export const scriptBlipLight = new Script({
     id: "blip_light",
-    parameters: {led_index: 'int'},
+    parameters: { led_index: 'int' },
     mode: "parallel",
-    then: fadeOut
+    then: [{
+        'repeat': {
+            'count': iterations,
+            'then': [{
+                'light.addressable_set': {
+                    id: "ledstrip",
+                    range_from: lambda('return led_index;'),
+                    range_to: lambda('return led_index;'),
+                    red: brightness,
+                    green: brightness,
+                    blue: brightness,
+                    white: brightness,
+                },
+            }, {
+                'delay': '25ms'
+            }]
+        }
+    }]
 });

--- a/packages/localdeck-configurator/CHANGELOG.md
+++ b/packages/localdeck-configurator/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Change log for the configurator in #37
+- Use native `repeat` action for the `blip_light` effect in #39
 
 ### Fixed
 


### PR DESCRIPTION
While configuring the device in YAML form, testing new device interactions, I wanted to simplify the generated script `blip_light` to be less verbose in its YAML form. This uses the [native repeat action](https://esphome.io/automations/actions.html#repeat-action) from ESPHOME. 

Fixes #31 

The original codegen output:
https://github.com/LocalBytes/localdeck-config/blob/9fa3704d7e8937e87561d747afbc43a770fdb94b/packages/localdeck-codegen/esphome-localdeck.yaml#L1165-L1350

New generated output
```yaml
  - id: blip_light
    parameters:
      led_index: int
    mode: parallel
    then:
      - repeat:
          count: '20'
          then:
            - light.addressable_set:
                id: ledstrip
                range_from: !lambda return led_index;
                range_to: !lambda return led_index;
                red: !lambda return 1.0 - ((float)iteration / 20);
                green: !lambda return 1.0 - ((float)iteration / 20);
                blue: !lambda return 1.0 - ((float)iteration / 20);
                white: !lambda return 1.0 - ((float)iteration / 20);
            - delay: 25ms
```