### PR TITLE
Fix Flash LED on press toggle becoming stuck when entity field is cleared

### DIFF
--- a/packages/localdeck-codegen/src/virtuals/configured-button.ts
+++ b/packages/localdeck-codegen/src/virtuals/configured-button.ts
@@ -19,11 +19,14 @@ export const BUTTON_NUMBERS = [
 
 export const zButtonNumber = z.coerce.number().min(1).max(24);
 
+const emptyToNullable = <T extends z.ZodString>(schema: T) =>
+    z.preprocess(val => val === '' ? null : val, schema.nullable());
+
 export const zConfiguredButtonOptsComponent = z.object({
     num: zButtonNumber,
     expose: z.boolean().default(true),
     blip_on_press: z.boolean().default(true),
-    ha_entity: z.string().nullish().default(""),
+    ha_entity: z.string().apply(emptyToNullable).default(null),
     toggle: z.boolean().default(true),
     follow_state: z.boolean().default(true),
     follow_brightness: z.boolean().default(true),
@@ -31,8 +34,8 @@ export const zConfiguredButtonOptsComponent = z.object({
 });
 
 export const zConfiguredButtonOptsLabel = z.object({
-    text: z.string().nullish().default(""),
-    icon: z.string().nullish().default(""),
+    text: z.string().apply(emptyToNullable).default(null),
+    icon: z.string().apply(emptyToNullable).default(null),
     fontSize: z.coerce.number().default(12),
 });
 

--- a/packages/localdeck-components/src/components/DeckButtonConfigActions.vue
+++ b/packages/localdeck-components/src/components/DeckButtonConfigActions.vue
@@ -30,12 +30,12 @@
           <span class="label-text">Entity</span>
           <DeckButtonConfigTypeahead
             v-if="typeahead"
-            v-model="modelValue.component.ha_entity"
+            v-model="haEntity"
             :typeahead="typeahead"
           />
           <input
             v-else
-            v-model="modelValue.component.ha_entity"
+            v-model="haEntity"
             v-maska
             class="input input-bordered"
             data-maska="D.E"
@@ -98,8 +98,9 @@
 import type Fuse from 'fuse.js';
 import type { EditContainer } from '../utils/PadCfg';
 import type { HassEntity } from '../utils/types';
+import { useNullableModel } from '../utils/hooks';
 
-defineModel<EditContainer>({
+const modelValue = defineModel<EditContainer>({
   required: true,
 });
 
@@ -108,4 +109,5 @@ defineProps<{
 }>();
 
 const hassOpen = ref(true);
+const haEntity = useNullableModel(modelValue.value.component, 'ha_entity');
 </script>

--- a/packages/localdeck-components/src/utils/hooks.ts
+++ b/packages/localdeck-components/src/utils/hooks.ts
@@ -1,3 +1,10 @@
+export function useNullableModel<T extends object, K extends keyof T>(obj: T, key: K) {
+  return computed<string>({
+    get: () => (obj[key] as string | null) ?? '',
+    set: (val) => { obj[key] = (val || null) as T[K]; },
+  });
+}
+
 export const isPrintingSymbol = Symbol('isPrinting');
 export const useIsPrinting = () => (inject(isPrintingSymbol, ref(false)) as Ref<boolean>);
 

--- a/packages/localdeck-components/test/nuxt/DeckButtonConfigActions.test.ts
+++ b/packages/localdeck-components/test/nuxt/DeckButtonConfigActions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { zConfiguredButtonOpts } from '@localbytes/localdeck-codegen/dist/virtuals';
+import DeckButtonConfigActions from '../../src/components/DeckButtonConfigActions.vue';
+
+const newButton = (componentOverrides: Record<string, unknown> = {}) =>
+  zConfiguredButtonOpts.parse({ keyNum: 1, label: {}, component: { num: 1, ...componentOverrides } });
+
+describe('DeckButtonConfigActions', () => {
+  it('Flash LED on press is enabled after clearing ha_entity', async () => {
+    const container = newButton({ ha_entity: 'light.living_room', follow_state: true });
+
+    const wrapper = mount(DeckButtonConfigActions, {
+      props: { modelValue: container, typeahead: null as unknown as never },
+    });
+
+    // Clear the entity via the input
+    const entityInput = wrapper.find('input[type="text"]');
+    await entityInput.setValue('');
+
+    const flashCheckbox = wrapper
+      .findAll('input[type="checkbox"]')
+      .find(w => w.element.closest('label')?.textContent?.includes('Flash LED on press'));
+
+    expect(flashCheckbox?.element.disabled).toBe(false);
+  });
+});

--- a/packages/localdeck-components/test/unit/config-util.test.ts
+++ b/packages/localdeck-components/test/unit/config-util.test.ts
@@ -113,12 +113,12 @@ describe('ConfigUtil', () => {
     const util = new ConfigUtil();
     const editor = util.editor();
 
-    expect(editor.buttons[1].label.text).toEqual('');
+    expect(editor.buttons[1].label.text).toEqual(null);
 
     editor.buttons[1].label.text = 'test';
     util.resetChanges('buttons.1.label');
 
-    expect(editor.buttons[1].label.text).toEqual('');
+    expect(editor.buttons[1].label.text).toEqual(null);
   });
 
   it('should allow setting changes', () => {


### PR DESCRIPTION
When a button had a HA entity set and then cleared, the Flash LED on press toggle would grey out and stay disabled, even after saving.
The root cause was `ha_entity` (and label `text`/`icon`) defaulting to an empty string rather than `null`, so the downstream disabled state check was seeing a truthy value after clearing.

We now coerce empty strings to `null` on those fields via a shared `emptyToNullable` preprocessor in the Zod schema, and add a `useNullableModel` composable to bridge null and empty string for the Vue input bindings.

Fixes: #36