### PR TITLE
Make very short button presses reliably reach Home Assistant

### DIFF
--- a/packages/localdeck-codegen/esphome-localdeck.yaml
+++ b/packages/localdeck-codegen/esphome-localdeck.yaml
@@ -38,9 +38,15 @@ output:
     id: improv_status
     type: binary
     write_action:
-      - light.control:
-          id: keypad_button_01_light
-          state: !lambda return state;
+      - if:
+          condition:
+            - lambda: return state;
+          then:
+            - light.turn_on:
+                id: keypad_button_01_light
+          else:
+            - light.turn_off:
+                id: keypad_button_01_light
 esp32_improv:
   status_indicator: improv_status
   authorizer: keypad_button_01
@@ -54,7 +60,9 @@ light:
     name: Ledstrip
     id: ledstrip
     rgb_order: GRB
-    pin: GPIO8
+    pin:
+      number: GPIO8
+      ignore_strapping_warning: true
     num_leds: 24
     chipset: SK6812
     restore_mode: RESTORE_AND_OFF
@@ -593,59 +601,39 @@ matrix_keypad:
         number: GPIO6
         drive_strength: 5mA
 script:
-  - id: blip_light
-    parameters:
-      led_index: int
-    mode: parallel
-    then:
-      - repeat:
-          count: '20'
-          then:
-            - light.addressable_set:
-                id: ledstrip
-                range_from: !lambda return led_index;
-                range_to: !lambda return led_index;
-                red: !lambda return 1.0 - ((float)iteration / 20);
-                green: !lambda return 1.0 - ((float)iteration / 20);
-                blue: !lambda return 1.0 - ((float)iteration / 20);
-                white: !lambda return 1.0 - ((float)iteration / 20);
-            - delay: 25ms
-  - id: set_led_rgb
-    parameters:
-      color: string
-      entity: string
-    mode: queued
-    then:
-      - lambda: |-
-          ESP_LOGD("set_led_rgb", "Entity %s, Input: %s", entity.c_str(), color.c_str());
-
-          if (color.length() < 7) return;
-
-          int firstComma = color.find(',');
-          int secondComma = color.find(',', firstComma + 1);
-
-          ESP_LOGV("set_led_rgb", "Commas are: %d, %d", firstComma, secondComma);
-
-          float r = stoi(color.substr(1, firstComma));
-          float g = stoi(color.substr(firstComma + 1, secondComma));
-          float b = stoi(color.substr(secondComma + 1, color.length() - 1));
-
-          ESP_LOGD("set_led_rgb", "%d, %d, %d", r,g,b);
-
-          for (auto *light : App.get_lights()){
-            ESP_LOGV("set_led_rgb", "Checking light %s", light->get_object_id().c_str());
-            if (light->get_object_id().c_str() == entity){
-                ESP_LOGD("set_led_rgb", "Setting light %s", light->get_object_id().c_str());
-                auto call = light->make_call();
-                call.set_rgb(r/255, g/255, b/255);
-                call.perform();
-            }
-          }
+  id: blip_light
+  parameters:
+    led_index: int
+  mode: parallel
+  then:
+    - repeat:
+        count: '20'
+        then:
+          - light.addressable_set:
+              id: ledstrip
+              range_from: !lambda return led_index;
+              range_to: !lambda return led_index;
+              red: !lambda return 1.0 - ((float)iteration / 20);
+              green: !lambda return 1.0 - ((float)iteration / 20);
+              blue: !lambda return 1.0 - ((float)iteration / 20);
+              white: !lambda return 1.0 - ((float)iteration / 20);
+          - delay: 25ms
 globals:
-  id: brightness
-  type: float
-  initial_value: '1'
-  restore_value: true
+  - id: apply_rgb_color
+    type: const std::function<void(std::string, esphome::light::LightState*)>
+    initial_value: |-
+      [](std::string color, esphome::light::LightState* light) {
+        if (color == "None") return;
+        int r, g, b;
+        if (sscanf(color.c_str(), "(%d, %d, %d)", &r, &g, &b) != 3) return;
+        auto call = light->make_call();
+        call.set_rgb(r/255.0f, g/255.0f, b/255.0f);
+        call.perform();
+      }
+  - id: brightness
+    type: float
+    initial_value: '1'
+    restore_value: true
 number:
   - platform: template
     name: Brightness
@@ -664,12 +652,16 @@ binary_sensor:
     id: keypad_button_01
     name: Button 01
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: A
     on_press:
       - script.execute:
           id: blip_light
           led_index: 0
+      - delay: 500ms
+      - lambda: id(keypad_button_01_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -700,12 +692,16 @@ binary_sensor:
     id: keypad_button_10
     name: Button 10
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: J
     on_press:
       - script.execute:
           id: blip_light
           led_index: 9
+      - delay: 500ms
+      - lambda: id(keypad_button_10_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -736,12 +732,16 @@ binary_sensor:
     id: keypad_button_11
     name: Button 11
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: K
     on_press:
       - script.execute:
           id: blip_light
           led_index: 10
+      - delay: 500ms
+      - lambda: id(keypad_button_11_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -772,12 +772,16 @@ binary_sensor:
     id: keypad_button_12
     name: Button 12
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: L
     on_press:
       - script.execute:
           id: blip_light
           led_index: 11
+      - delay: 500ms
+      - lambda: id(keypad_button_12_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -808,12 +812,16 @@ binary_sensor:
     id: keypad_button_13
     name: Button 13
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: M
     on_press:
       - script.execute:
           id: blip_light
           led_index: 12
+      - delay: 500ms
+      - lambda: id(keypad_button_13_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -844,12 +852,16 @@ binary_sensor:
     id: keypad_button_14
     name: Button 14
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: 'N'
     on_press:
       - script.execute:
           id: blip_light
           led_index: 13
+      - delay: 500ms
+      - lambda: id(keypad_button_14_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -880,12 +892,16 @@ binary_sensor:
     id: keypad_button_15
     name: Button 15
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: O
     on_press:
       - script.execute:
           id: blip_light
           led_index: 14
+      - delay: 500ms
+      - lambda: id(keypad_button_15_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -916,12 +932,16 @@ binary_sensor:
     id: keypad_button_16
     name: Button 16
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: P
     on_press:
       - script.execute:
           id: blip_light
           led_index: 15
+      - delay: 500ms
+      - lambda: id(keypad_button_16_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -952,12 +972,16 @@ binary_sensor:
     id: keypad_button_17
     name: Button 17
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: Q
     on_press:
       - script.execute:
           id: blip_light
           led_index: 16
+      - delay: 500ms
+      - lambda: id(keypad_button_17_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -988,12 +1012,16 @@ binary_sensor:
     id: keypad_button_18
     name: Button 18
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: R
     on_press:
       - script.execute:
           id: blip_light
           led_index: 17
+      - delay: 500ms
+      - lambda: id(keypad_button_18_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1024,12 +1052,16 @@ binary_sensor:
     id: keypad_button_19
     name: Button 19
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: S
     on_press:
       - script.execute:
           id: blip_light
           led_index: 18
+      - delay: 500ms
+      - lambda: id(keypad_button_19_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1060,12 +1092,16 @@ binary_sensor:
     id: keypad_button_02
     name: Button 02
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: B
     on_press:
       - script.execute:
           id: blip_light
           led_index: 1
+      - delay: 500ms
+      - lambda: id(keypad_button_02_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1096,12 +1132,16 @@ binary_sensor:
     id: keypad_button_20
     name: Button 20
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: T
     on_press:
       - script.execute:
           id: blip_light
           led_index: 19
+      - delay: 500ms
+      - lambda: id(keypad_button_20_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1132,12 +1172,16 @@ binary_sensor:
     id: keypad_button_21
     name: Button 21
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: U
     on_press:
       - script.execute:
           id: blip_light
           led_index: 20
+      - delay: 500ms
+      - lambda: id(keypad_button_21_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1168,12 +1212,16 @@ binary_sensor:
     id: keypad_button_22
     name: Button 22
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: V
     on_press:
       - script.execute:
           id: blip_light
           led_index: 21
+      - delay: 500ms
+      - lambda: id(keypad_button_22_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1204,12 +1252,16 @@ binary_sensor:
     id: keypad_button_23
     name: Button 23
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: W
     on_press:
       - script.execute:
           id: blip_light
           led_index: 22
+      - delay: 500ms
+      - lambda: id(keypad_button_23_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1240,12 +1292,16 @@ binary_sensor:
     id: keypad_button_24
     name: Button 24
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: X
     on_press:
       - script.execute:
           id: blip_light
           led_index: 23
+      - delay: 500ms
+      - lambda: id(keypad_button_24_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1276,12 +1332,16 @@ binary_sensor:
     id: keypad_button_03
     name: Button 03
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: C
     on_press:
       - script.execute:
           id: blip_light
           led_index: 2
+      - delay: 500ms
+      - lambda: id(keypad_button_03_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1312,12 +1372,16 @@ binary_sensor:
     id: keypad_button_04
     name: Button 04
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: D
     on_press:
       - script.execute:
           id: blip_light
           led_index: 3
+      - delay: 500ms
+      - lambda: id(keypad_button_04_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1348,12 +1412,16 @@ binary_sensor:
     id: keypad_button_05
     name: Button 05
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: E
     on_press:
       - script.execute:
           id: blip_light
           led_index: 4
+      - delay: 500ms
+      - lambda: id(keypad_button_05_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1384,12 +1452,16 @@ binary_sensor:
     id: keypad_button_06
     name: Button 06
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: F
     on_press:
       - script.execute:
           id: blip_light
           led_index: 5
+      - delay: 500ms
+      - lambda: id(keypad_button_06_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1420,12 +1492,16 @@ binary_sensor:
     id: keypad_button_07
     name: Button 07
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: G
     on_press:
       - script.execute:
           id: blip_light
           led_index: 6
+      - delay: 500ms
+      - lambda: id(keypad_button_07_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1456,12 +1532,16 @@ binary_sensor:
     id: keypad_button_08
     name: Button 08
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: H
     on_press:
       - script.execute:
           id: blip_light
           led_index: 7
+      - delay: 500ms
+      - lambda: id(keypad_button_08_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:
@@ -1492,12 +1572,16 @@ binary_sensor:
     id: keypad_button_09
     name: Button 09
     internal: false
+    filters:
+      - delayed_off: 125ms
     keypad_id: keypad
     key: I
     on_press:
       - script.execute:
           id: blip_light
           led_index: 8
+      - delay: 500ms
+      - lambda: id(keypad_button_09_light).make_call().perform();
     on_click: []
     on_double_click: []
     on_multi_click:

--- a/packages/localdeck-codegen/src/virtuals/configured-button.ts
+++ b/packages/localdeck-codegen/src/virtuals/configured-button.ts
@@ -58,6 +58,7 @@ export class ConfiguredButton extends VirtualComponent<ConfiguredButtonOpts> {
             id: `keypad_button_${c.num.toString().padStart(2, "0")}`,
             name: `Button ${c.num.toString().padStart(2, "0")}`,
             internal: !c.expose,
+            filters: [{ delayed_off: '125ms' }],
             keypad_id: 'keypad',
             key: KEYS[c.num - 1],
             on_press: [],

--- a/packages/localdeck-configurator/CHANGELOG.md
+++ b/packages/localdeck-configurator/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Button LEDs now correctly reflect colour and brightness from Home Assistant entities in #144
 - Suppressed a spurious boot warning for the LED strip pin in #144
 - Fixed provisioning indicator (button 01 LED) broken by ESPHome 2026.5 in #143
+- Very short button presses now reliably reach Home Assistant in #163
 
 ## [v0.7](https://github.com/LocalBytes/localdeck-config/releases/tag/v0.7)
 


### PR DESCRIPTION
When a button is pressed and released very quickly, ESPHome's API batching (100ms window by default) can collapse the press and release into a single batch cycle, meaning Home Assistant never sees the state change — even though the device registers the press and plays the animation.

This adds a `delayed_off: 125ms` filter to each button's binary sensor so the "on" state is held for at least one batch window before turning off. The delay is imperceptible to users but ensures the state change is always transmitted to HA.

Fixes: #57