### PR TITLE
Replace `get_object_id` with `get_object_id_to`

### DIFF
--- a/packages/localdeck-codegen/esphome-localdeck.yaml
+++ b/packages/localdeck-codegen/esphome-localdeck.yaml
@@ -633,9 +633,13 @@ script:
           ESP_LOGD("set_led_rgb", "%d, %d, %d", r,g,b);
 
           for (auto *light : App.get_lights()){
-            ESP_LOGV("set_led_rgb", "Checking light %s", light->get_object_id().c_str());
-            if (light->get_object_id().c_str() == entity){
-                ESP_LOGD("set_led_rgb", "Setting light %s", light->get_object_id().c_str());
+            char object_id_buf[OBJECT_ID_MAX_LEN];
+            auto light_object_id = light->get_object_id_to(object_id_buf).c_str();
+
+            ESP_LOGV("set_led_rgb", "Checking light %s", light_object_id);
+
+            if (light_object_id == entity){
+                ESP_LOGD("set_led_rgb", "Setting light %s", light_object_id);
                 auto call = light->make_call();
                 call.set_rgb(r/255, g/255, b/255);
                 call.perform();


### PR DESCRIPTION
Fixes #168

Implementation inspired by https://github.com/LocalBytes/localdeck-config/issues/168#issuecomment-5002156468, but optimised to avoid duplicate buffer writes. Get the id once and reuse it.