### PR TITLE
Use correct format replacement when logging LED RGB values

### DIFF
--- a/packages/localdeck-codegen/esphome-localdeck.yaml
+++ b/packages/localdeck-codegen/esphome-localdeck.yaml
@@ -630,7 +630,7 @@ script:
           float g = stoi(color.substr(firstComma + 1, secondComma));
           float b = stoi(color.substr(secondComma + 1, color.length() - 1));
 
-          ESP_LOGD("set_led_rgb", "%d, %d, %d", r,g,b);
+          ESP_LOGD("set_led_rgb", "%f, %f, %f", r,g,b);
 
           for (auto *light : App.get_lights()){
             ESP_LOGV("set_led_rgb", "Checking light %s", light->get_object_id().c_str());


### PR DESCRIPTION
```
/data/packages/90d066c3/packages/localdeck-codegen/esphome-localdeck.yaml:633:31: warning: format '%d' expects argument of type 'int', but argument 5 has type 'double' [-Wformat=]
  633 |           ESP_LOGD("set_led_rgb", "%d, %d, %d", r,g,b);
      |                               ^~~~~~~~~~~~
../src/esphome/core/log.h:83:36: note: in definition of macro 'ESPHOME_LOG_FORMAT'
   83 | #define ESPHOME_LOG_FORMAT(format) format
      |                                    ^~~~~~
../src/esphome/core/log.h:163:28: note: in expansion of macro 'esph_log_d'
  163 | #define ESP_LOGD(tag, ...) esph_log_d(tag, __VA_ARGS__)
      |                            ^~~~~~~~~~
```

I believe the correct behaviour is to format them as a float (`%f`).

- https://stackoverflow.com/a/4264154
- https://en.cppreference.com/cpp/utility/format/spec